### PR TITLE
chore: mainブランチへマージ時にgit workflowが動作しないよう修正

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,8 @@
 name: frontend-ci
-on: push
+on:
+  push:
+    branches-ignore:
+      - main
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 概要
mainブランチまーじじにもlint確認用git workflowが動作してしまうため動かないように修正

## 実装内容
- git workflowのpush時の動作にてmainブランチを無視する記述を追加

## レビューポイント
- [ ] mainブランチマージ時にgithub actionsが動かない

## 備考
